### PR TITLE
Improve PostgreSQL support

### DIFF
--- a/src/TableDroppers/Pgsql.php
+++ b/src/TableDroppers/Pgsql.php
@@ -5,7 +5,7 @@ namespace Spatie\MigrateFresh\TableDroppers;
 use DB;
 use Illuminate\Support\Collection;
 
-class Postgresql implements TableDropper
+class Pgsql implements TableDropper
 {
     public function dropAllTables()
     {

--- a/src/TableDroppers/Pgsql.php
+++ b/src/TableDroppers/Pgsql.php
@@ -37,7 +37,7 @@ class Pgsql implements TableDropper
     protected function getTables($schema)
     {
         return collect(
-            DB::select("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = ?", [$schema])
+            DB::select('SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = ?', [$schema])
         )->pluck('tablename');
     }
 

--- a/src/TableDroppers/Postgresql.php
+++ b/src/TableDroppers/Postgresql.php
@@ -3,17 +3,51 @@
 namespace Spatie\MigrateFresh\TableDroppers;
 
 use DB;
+use Illuminate\Support\Collection;
 
 class Postgresql implements TableDropper
 {
     public function dropAllTables()
     {
-        $tableProperties = DB::select("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname='public'");
+        $tables = $this->getTables($this->getSchema());
 
-        $tableNames = array_column($tableProperties, 'tablename');
-
-        foreach ($tableNames as $tableName) {
-            DB::statement("DROP TABLE {$tableName} CASCADE");
+        if ($tables->isEmpty()) {
+            return;
         }
+
+        $this->drop($tables);
+    }
+
+    /**
+     * Drop tables.
+     *
+     * @param \Illuminate\Support\Collection $tables
+     */
+    protected function drop(Collection $tables)
+    {
+        DB::statement("DROP TABLE {$tables->implode(',')} CASCADE");
+    }
+
+    /**
+     * Get a list of all tables in the schema.
+     *
+     * @param $schema
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getTables($schema)
+    {
+        return collect(
+            DB::select("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = ?", [$schema])
+        )->pluck('tablename');
+    }
+
+    /**
+     * Get schema name for the connection.
+     *
+     * @return string
+     */
+    protected function getSchema()
+    {
+        return DB::getConfig('schema');
     }
 }


### PR DESCRIPTION
Read the schema from the connection
> one doesn't have to always use the default `public` schema

Drop tables in one statement
> to make an atomic DDL operation (hopefully)

Match the PostgreSQL driver name - pgsql
> Have to match the driver name otherwise one would always get
```
[Spatie\MigrateFresh\Exceptions\CannotDropTables]
  The migrate:fresh command does not support `pgsql`-databases.
```