### PR TITLE
Drop PostgreSQL tables in multiple schemas using "used_schemas" config

### DIFF
--- a/src/TableDroppers/Pgsql.php
+++ b/src/TableDroppers/Pgsql.php
@@ -24,8 +24,14 @@ class Pgsql implements TableDropper
      */
     protected function getTableNames()
     {
+        $schemas = DB::getConfig('used_schemas') ?: [DB::getConfig('schema')];
+
+        $schemas_count = count($schemas);
+
+        $binds = implode(',', array_fill(0, $schemas_count, '?'));
+
         return collect(
-            DB::select('SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = ?', [DB::getConfig('schema')])
-        )->pluck('tablename');
+            DB::select("SELECT schemaname || '.' || tablename AS table FROM pg_catalog.pg_tables WHERE schemaname IN (" . $binds . ")", $schemas)
+        )->pluck('table');
     }
 }


### PR DESCRIPTION
With this commit is possible drop pgsql tables in multiple schemas.

Added a config attribute ``used_schemas`` in ``config/database.php``:

```php
// config/database.php

        'pgsql'  => [
            'driver'       => 'pgsql',
            'host'         => env('DB_HOST', '127.0.0.1'),
            'port'         => env('DB_PORT', '5432'),
            'database'     => env('DB_DATABASE', 'forge'),
            'username'     => env('DB_USERNAME', 'forge'),
            'password'     => env('DB_PASSWORD', ''),
            'charset'      => 'utf8',
            'prefix'       => '',
            'schema'       => 'public',
            'sslmode'      => 'prefer',
            'used_schemas' => ['public', 'config', 'core'],
        ],
```