### PR TITLE
Refactor sqlsrv dropper to use only documented functions

### DIFF
--- a/src/TableDroppers/Sqlsrv.php
+++ b/src/TableDroppers/Sqlsrv.php
@@ -6,27 +6,28 @@ use Illuminate\Support\Facades\DB;
 
 class Sqlsrv implements TableDropper
 {
-    private $constraintDropScript = '
-        DECLARE @Sql NVARCHAR(500) DECLARE @Cursor CURSOR
-        SET @Cursor = CURSOR FAST_FORWARD FOR
-        SELECT DISTINCT sql = \'ALTER TABLE [\'+tc2.CONSTRAINT_SCHEMA+\'].[\' + tc2.TABLE_NAME + \'] DROP [\' + rc1.CONSTRAINT_NAME + \']\'
-        FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc1
-        LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc2 ON tc2.CONSTRAINT_NAME =rc1.CONSTRAINT_NAME
-        
-        OPEN @Cursor FETCH NEXT FROM @Cursor INTO @Sql
-        
-        WHILE (@@FETCH_STATUS = 0)
-        BEGIN
-        PRINT @Sql
-        Exec (@Sql)
-        FETCH NEXT FROM @Cursor INTO @Sql
-        END
-        
-        CLOSE @Cursor DEALLOCATE @Cursor';
+    private $dropScript = '
+		while(exists(select 1 from INFORMATION_SCHEMA.TABLE_CONSTRAINTS where CONSTRAINT_TYPE=\'FOREIGN KEY\'))
+		begin
+			declare @sql nvarchar(2000)
+			SELECT TOP 1 @sql=(\'ALTER TABLE \' + TABLE_SCHEMA + \'.[\' + TABLE_NAME + \'] DROP CONSTRAINT [\' + CONSTRAINT_NAME + \']\')
+			FROM information_schema.table_constraints
+			WHERE CONSTRAINT_TYPE = \'FOREIGN KEY\'
+			exec (@sql)
+		end
+		
+		
+		while(exists(select 1 from INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA != \'sys\'))
+		begin
+			declare @sql1 nvarchar(2000)
+			SELECT TOP 1 @sql1=(\'DROP TABLE \' + TABLE_SCHEMA + \'.[\' + TABLE_NAME + \']\')
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_SCHEMA != \'sys\'
+			exec (@sql1)
+		end';
 
     public function dropAllTables()
     {
-        DB::unprepared($this->constraintDropScript);
-        DB::unprepared("exec sp_MSforeachtable 'DROP TABLE ?'");
+        DB::unprepared($this->dropScript);
     }
 }


### PR DESCRIPTION
Original dropper script uses some undocumented functions (like sp_MSforeachtable), which might not work in newer versions of MS SQL.
Now, its already not working in Azure SQL.
New script should work in all current versions including Azure SQL.